### PR TITLE
Fix SSM parameter name comparison

### DIFF
--- a/src/aft_lambda/aft_account_provisioning_framework/aft_account_provisioning_framework_account_metadata_ssm.py
+++ b/src/aft_lambda/aft_account_provisioning_framework/aft_account_provisioning_framework_account_metadata_ssm.py
@@ -73,7 +73,7 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> None:
         )
 
         existing_keys = set(params)
-        new_keys = set(custom_fields.keys())
+        new_keys = set([SSM_PARAMETER_PATH + key for key in custom_fields.keys()])
 
         # Delete SSM parameters which do not exist in new custom fields
         params_to_remove = list(existing_keys.difference(new_keys))


### PR DESCRIPTION
Resolves [#531](https://github.com/aws-ia/terraform-aws-control_tower_account_factory/issues/531).